### PR TITLE
Limit search to desktop until mobile experience improved

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ permalink: /
         <div class="section-title">
           <h2>Resources</h2>
           <p>Seeking legal help? Check out the following resources.</p>
-          <label class="search-container">
+          <label class="search-container hidden-xs hidden-sm">
             <input class="search" placeholder="Search">
             <i class="ion-search search-icon"></i>
           </label>


### PR DESCRIPTION
Noticed that the initial search functionality that #18 provides isn't as intuitive on mobile devices, difficult for user to notice that resources are being filtered, since bulk of content is off screen. 

Figured it might be best to limit search to desktop until additional time can be spent on mobile search experience. Screen recording of problem for easy reference:

![render](https://d3vv6lp55qjaqc.cloudfront.net/items/211G2D1G1H473T1L2I1N/Screen%20Recording%202017-02-01%20at%2009.35%20AM.gif?X-CloudApp-Visitor-Id=1316007&v=9328f335)

/fyi @aymannadeem @rewinfrey 